### PR TITLE
Add: translation from python to rust

### DIFF
--- a/src/teenygrad/shape/symbolic.rs
+++ b/src/teenygrad/shape/symbolic.rs
@@ -1,0 +1,1 @@
+pub type Sint = i32;


### PR DESCRIPTION
Closes #24 

To my understanding, the  ```sint = int``` in ```symbolic.py``` is creating an alias of the inbuilt ```int``` data type in python.

In rust 
```rust
pub type Sint = i32;
```
meaning that wherever you use ```Sint``` in your Rust code, it's equivalent to using ```i32``` representing a 32-bit signed integer..