### PR TITLE
Fix: no capitalization

### DIFF
--- a/src/teenygrad/shape/symbolic.rs
+++ b/src/teenygrad/shape/symbolic.rs
@@ -1,1 +1,1 @@
-pub type Sint = i32;
+pub type sint = i32;


### PR DESCRIPTION
I do not think we should have capitalization on 

```rust
sint
```

idk personal preference, you can fight me on this Jay if you'd like.

I did not do an issue for this, its way too minor.