### PR TITLE
Fix: realize.rs warning

### DIFF
--- a/src/teenygrad/realize.rs
+++ b/src/teenygrad/realize.rs
@@ -1,6 +1,6 @@
-pub fn run_schedule(schedule: Vec<i32>) -> std::io::Result<()> {
+pub fn run_schedule(_schedule: Vec<i32>) -> std::io::Result<()> {
     return Ok(());
 }
-pub fn create_schedule(outs: Vec<i32>) -> Vec<i32> {
+pub fn create_schedule(_outs: Vec<i32>) -> Vec<i32> {
     return vec![];
 }


### PR DESCRIPTION
This just adds a `_` to the begining of variable names since they will be unused.